### PR TITLE
Handle preprocessor directives before parsing

### DIFF
--- a/wow
+++ b/wow
@@ -16,10 +16,19 @@ except FileNotFoundError:
     print(f"Error: file '{path}' not found.")
     exit(1)
 
+# Strip out preprocessor directives which pycparser can't handle directly.
+sanitized_lines = []
+for line in content.splitlines():
+    if line.lstrip().startswith("#"):
+        sanitized_lines.append("")
+    else:
+        sanitized_lines.append(line)
+sanitized_content = "\n".join(sanitized_lines)
+
 # Parse C code into an AST
 parser = c_parser.CParser()
 try:
-    ast = parser.parse(content, filename=path)
+    ast = parser.parse(sanitized_content, filename=path)
 except Exception as e:
     print(f"Parsing error: {e}")
     exit(1)


### PR DESCRIPTION
### **User description**
## Summary
- strip preprocessor directives from source before parsing so pycparser can handle the input

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2aeea44c883209777a7d3c87390eb


___

### **PR Type**
Bug fix


___

### **Description**
- Strip preprocessor directives before parsing C code

- Replace directives with empty lines to preserve line numbers

- Fix pycparser compatibility issues with preprocessor syntax


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["C source code"] --> B["Strip preprocessor directives"] --> C["Parse with pycparser"] --> D["AST output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wow</strong><dd><code>Add preprocessor directive sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

wow

<ul><li>Add preprocessing step to strip directives starting with '#'<br> <li> Replace preprocessor lines with empty lines to maintain line numbers<br> <li> Update parser call to use sanitized content instead of raw content</ul>


</details>


  </td>
  <td><a href="https://github.com/eotter-beep/wow/pull/1/files#diff-b6dc933311bc2357cc5fc636a4dbe41a01b7a33b583d043a7f870f3440697e27">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

